### PR TITLE
Only fetch alerts on umich.edu domain.

### DIFF
--- a/packages/components/src/components/website-alerts/website-alerts.tsx
+++ b/packages/components/src/components/website-alerts/website-alerts.tsx
@@ -10,32 +10,38 @@ export class WebsiteAlerts {
   @State() alerts;
 
   componentWillLoad() {
-    this.status = "loading";
-    fetch("https://staff.lib.umich.edu/api/alerts")
-      .then(response => response.json())
-      .then(result => {
-        const hostname = window.location.hostname;
-        const alertsThatTargetHost = result.reduce((memo, alert) => {
-          const domains = alert.domains.split(", ");
+    const domain = document.domain;
 
-          if (domains.includes(hostname)) {
-            memo = memo.concat(alert);
+    if (domain.includes("lib.umich.edu")) {
+      this.status = "loading";
+
+      fetch("https://staff.lib.umich.edu/api/alerts")
+        .then(response => response.json())
+        .then(result => {
+          const alertsThatTargetHost = result.reduce((memo, alert) => {
+            const domains = alert.domains.split(", ");
+
+            if (domains.includes(domain)) {
+              memo = memo.concat(alert);
+            }
+
+            return memo;
+          }, []);
+
+          if (alertsThatTargetHost.length > 0) {
+            this.alerts = alertsThatTargetHost;
+            this.status = "success";
+          } else {
+            this.status = "no-alerts";
           }
-
-          return memo;
-        }, []);
-
-        if (alertsThatTargetHost.length > 0) {
-          this.alerts = alertsThatTargetHost;
-          this.status = "success";
-        } else {
-          this.status = "no-alerts";
-        }
-      })
-      .catch(e => {
-        this.status = "error";
-        console.warn("Unable to fetch U-M Library Website Alerts.", e);
-      });
+        })
+        .catch(e => {
+          this.status = "error";
+          console.warn("Unable to fetch U-M Library Website Alerts.", e);
+        });
+    } else {
+      this.status = "invalid-domain";
+    }
   }
 
   render() {

--- a/packages/components/src/components/website-alerts/website-alerts.tsx
+++ b/packages/components/src/components/website-alerts/website-alerts.tsx
@@ -12,7 +12,7 @@ export class WebsiteAlerts {
   componentWillLoad() {
     const domain = document.domain;
 
-    if (domain.includes("lib.umich.edu")) {
+    if (domain.includes("umich.edu")) {
       this.status = "loading";
 
       fetch("https://staff.lib.umich.edu/api/alerts")


### PR DESCRIPTION
## Problem
We're limited with default CORS settings via the alerts api on Drupal; meaning we have to be on the same domain to fetch alerts successfully.

## Solution
To avoid `304` and CORS confusion with alerts being fetched then blocked or cached, this change limits this to only make the request when the component recognizes it is on the `lib.umich.edu` domain.

This change should avoid CORS related confusion.