### PR TITLE
Prevent caching of website alerts.

### DIFF
--- a/packages/components/src/components/website-alerts/website-alerts.tsx
+++ b/packages/components/src/components/website-alerts/website-alerts.tsx
@@ -15,7 +15,7 @@ export class WebsiteAlerts {
     if (domain.includes("umich.edu")) {
       this.status = "loading";
 
-      fetch("https://staff.lib.umich.edu/api/alerts", { cache: "no-cache" })
+      fetch("https://staff.lib.umich.edu/api/alerts", { cache: "reload" })
         .then(response => response.json())
         .then(result => {
           const alertsThatTargetHost = result.reduce((memo, alert) => {

--- a/packages/components/src/components/website-alerts/website-alerts.tsx
+++ b/packages/components/src/components/website-alerts/website-alerts.tsx
@@ -15,7 +15,7 @@ export class WebsiteAlerts {
     if (domain.includes("umich.edu")) {
       this.status = "loading";
 
-      fetch("https://staff.lib.umich.edu/api/alerts")
+      fetch("https://staff.lib.umich.edu/api/alerts", { cache: "no-cache" })
         .then(response => response.json())
         .then(result => {
           const alertsThatTargetHost = result.reduce((memo, alert) => {


### PR DESCRIPTION
End users may not see latest alerts because of caching. This change configures the alerts `fetch` to ask for no caching, so that alerts are always fetching the latest data.

The solution here uses the cache API option: https://javascript.info/fetch-api#cache

An alternative considered was:

```js
fetch("https://staff.lib.umich.edu/api/alerts?now=" + Date.now())
```