### PR TITLE
Avoid flash of invisible text with Google Font display swap.

### DIFF
--- a/packages/css/src/scss/_base.scss
+++ b/packages/css/src/scss/_base.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Crimson+Text|Muli:400,600,700");
+@import url("https://fonts.googleapis.com/css?family=Crimson+Text|Muli:400,600,700&display=swap");
 @import "custom-properties";
 
 :root {

--- a/packages/docs/_includes/layout.njk
+++ b/packages/docs/_includes/layout.njk
@@ -11,6 +11,7 @@ description: Documentation for the U-M Library Design System.
     <meta name="Description" content="{{ description }}">
     <link rel="icon" href="/static/images/favicon-32x32.png" type="image/png">
     <link rel="stylesheet" href="{{ '/css/index.css' | url }}"/>
+    <link href="https://fonts.googleapis.com/css?family=Crimson+Text|Muli:400,600,700&display=swap" rel="stylesheet">
     <link
       href="https://unpkg.com/@umich-lib/css@v1/dist/umich-lib.css"
       rel="stylesheet"


### PR DESCRIPTION
This change ensures text remains visible during webfont load. Primary reference: https://web.dev/font-display/